### PR TITLE
Add datetime method to time module

### DIFF
--- a/forgery_py/forgery/date.py
+++ b/forgery_py/forgery/date.py
@@ -25,7 +25,7 @@
 
 """Generate random date-related data."""
 
-import datetime
+import datetime as dt
 import random
 
 __all__ = ['day_of_week', 'month', 'year', 'day', 'date']
@@ -84,7 +84,7 @@ def _delta(past=False, min_delta=0, max_delta=20):
 
 def year(past=False, min_delta=0, max_delta=20):
     """Return a random year."""
-    return datetime.date.today().year + _delta(past, min_delta, max_delta)
+    return dt.date.today().year + _delta(past, min_delta, max_delta)
 
 
 def day(month_length=31):
@@ -93,6 +93,12 @@ def day(month_length=31):
 
 
 def date(past=False, min_delta=0, max_delta=20):
-    """Return a random `datetime.date` object. Delta args are days."""
-    timedelta = datetime.timedelta(days=_delta(past, min_delta, max_delta))
-    return datetime.date.today() + timedelta
+    """Return a random `dt.date` object. Delta args are days."""
+    timedelta = dt.timedelta(days=_delta(past, min_delta, max_delta))
+    return dt.date.today() + timedelta
+
+
+def datetime(past=False, min_delta=0, max_delta=20):
+    """Return a random `dt.dt` object. Delta args are days."""
+    timedelta = dt.timedelta(days=_delta(past, min_delta, max_delta))
+    return dt.datetime.today() + timedelta

--- a/forgery_py/forgery/time.py
+++ b/forgery_py/forgery/time.py
@@ -31,5 +31,5 @@ __all__ = ['zone']
 
 
 def zone():
-    """Return a random color name."""
+    """Return a random timezone."""
     return random.choice(get_dictionary('zones')).strip()

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -48,3 +48,12 @@ class DateForgeryTestCase(TestCase):
 
         result = date.date(past=True)
         assert result < today
+
+    def test_datetime(self):
+        today = datetime.datetime.today()
+
+        result = date.datetime()
+        assert result > today
+
+        result = date.datetime(past=True)
+        assert result < today


### PR DESCRIPTION
Added a method to `forgery_py.date` called `datetime` to generate `datetime.datetime` objects. Used named import to resolve names conflict. As far as I know, named imports are acceptable in such cases. 

Also fixed docstring for `forgery_py.time.zone` (sorry, in same pull request).

By the way, I think it would be nice to have both date and time related methods in one module `forgery_py.datetime` for consistency with Python standard library, but this is just my opinion.